### PR TITLE
Get the assets folder from the config, don't assume that it's /assets/

### DIFF
--- a/vendor/assets/javascripts/sencha-touch-rails.js.erb
+++ b/vendor/assets/javascripts/sencha-touch-rails.js.erb
@@ -1726,5 +1726,5 @@ Ext.ClassManager.addNameAliasMappings({
 });
 
 Ext.Loader.setPath({
-    'Ext': 'assets/sencha-touch'
+    'Ext': '<%= Rails.configuration.assets.prefix %>/sencha-touch'
 });


### PR DESCRIPTION
I'm using a different assets folder on my dev environment, in order to be able to compile and commit my assets for prod on Openshift (https://zherkingdom.wordpress.com/2014/12/10/compile-assets-locally-using-git-hooks-on-a-openshift-rails-app/). 
In the current state, it's assumed Sencha Touch will find the JS files at /assets/, which brakes my setup. 
This commit fixes that using the runtime configuration "Rails.configuration.assets.prefix", but the .js file needs to be renamed to .erb in order to process the Ruby code snippet.